### PR TITLE
[Fix]favoriteコントローラーのdestroyアクションを修正

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -46,7 +46,7 @@ class ArticlesController < ApplicationController
 
   def destroy
     @article = Article.find(params[:id])
-    @article.delete
+    @article.destroy
     flash[:notice] = '削除しました'
     redirect_to user_path(current_user)
   end


### PR DESCRIPTION
destroyアクション内のdeleteの記述をdestroyに修正。